### PR TITLE
Work-around numpy ValueError.

### DIFF
--- a/DeepBach/model_manager.py
+++ b/DeepBach/model_manager.py
@@ -296,6 +296,9 @@ class DeepBach:
                     probas_pitch = np.exp(probas_pitch) / np.sum(
                         np.exp(probas_pitch)) - 1e-7
 
+                    # avoid non-probabilities
+                    probas_pitch[probas_pitch < 0] = 0
+
                     # pitch can include slur_symbol
                     pitch = np.argmax(np.random.multinomial(1, probas_pitch))
 


### PR DESCRIPTION
In newer numpy versions (e.g. 1.17.4), the probabilities to a
multinomial are checked to be valid, within range [0,1].

Before this fix, running `python deepBach.py` gives the error:
...
  File "./DeepBach/model_manager.py", line 300, in parallel_gibbs
    pitch = np.argmax(np.random.multinomial(1, probas_pitch))
  File "mtrand.pyx", line 3866, in numpy.random.mtrand.RandomState.multinomial
  File "common.pyx", line 323, in numpy.random.common.check_array_constraint
ValueError: pvals < 0, pvals > 1 or pvals contains NaNs