### PR TITLE
Use local cache dir when loading dataset, not cache dir at save site.

### DIFF
--- a/DatasetManager/dataset_manager.py
+++ b/DatasetManager/dataset_manager.py
@@ -71,6 +71,7 @@ class DatasetManager:
         if os.path.exists(dataset.filepath):
             print(f'Loading {dataset.__repr__()} from {dataset.filepath}')
             dataset = torch.load(dataset.filepath)
+            dataset.cache_dir = self.cache_dir
             print(f'(the corresponding TensorDataset is not loaded)')
         else:
             print(f'Creating {dataset.__repr__()}, '


### PR DESCRIPTION
Use local cache dir when loading dataset, not cache dir at save site.

This allows training models with a cache directory downloaded from somewhere else (including the sh script).