### PR TITLE
Tweak info around Musescore Plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,7 @@ docker run --runtime=nvidia -p 5000:5000 -it --rm ghadjeres/deepbach
 ## Usage within MuseScore
 *Deprecated*
 
-This only works with MuseScore2.
-
-Put `deepBachMuseScore.qml` file in your `MuseScore2/Plugins` directory, and run
+Put `deepBachMuseScore.qml` file in your MuseScore plugins directory, and run
 ```
 python musescore_flask_server.py
 ```


### PR DESCRIPTION
The plugin specifically works with Musescore 3, not 2.
The Musescore plugins directory is OS-specific.